### PR TITLE
Text mode hooks should not modify the content

### DIFF
--- a/config.org
+++ b/config.org
@@ -4381,7 +4381,7 @@ It's nice to see ANSI colour codes displayed
   (add-hook! 'text-mode-hook
              ;; Apply ANSI color codes
              (with-silent-modifications
-               (ansi-color-apply-on-region (point-min) (point-max)))))
+               (ansi-color-apply-on-region (point-min) (point-max) t))))
 #+end_src
 ** Org
 :PROPERTIES:


### PR DESCRIPTION
This lead to ANSI codes being discarded on save